### PR TITLE
Bugfix: fix assigning identifiers when port specified

### DIFF
--- a/midi_router/midi_router.py
+++ b/midi_router/midi_router.py
@@ -176,7 +176,7 @@ class MidiRouter:
             available_long_names = available_short_names_to_long_names.get(port_info.name, [])
             if port_info.long_name in available_long_names:
                 available_long_names.remove(port_info.long_name)
-                identifiers_to_port_names[port_info.identifier] = long_name
+                identifiers_to_port_names[port_info.identifier] = port_info.long_name
             else:
                 identifiers_to_port_names[port_info.identifier] = None
 


### PR DESCRIPTION
It was using the wrong variable to assign the identifier.

I believe this will fix https://github.com/lzulauf/MidiRouter/issues/1